### PR TITLE
Use Decimal for drawdown haircut

### DIFF
--- a/tests/test_sizing_kelly.py
+++ b/tests/test_sizing_kelly.py
@@ -223,44 +223,50 @@ class TestKellySizing:
 
     def test_dd_haircut_factor(self):
         """Test DD haircut factor calculation."""
+        from decimal import Decimal
         from core.sizing.kelly import dd_haircut_factor, apply_dd_haircut_to_kelly
 
         # No drawdown
-        haircut = dd_haircut_factor(0.0)
-        assert haircut == 1.0
+        haircut = dd_haircut_factor(Decimal("0"))
+        assert haircut == Decimal("1")
 
         # Full drawdown
-        haircut = dd_haircut_factor(300.0)  # DD_max = 300
-        assert haircut == 0.0
+        haircut = dd_haircut_factor(Decimal("300"))  # DD_max = 300
+        assert haircut == Decimal("0")
 
         # Partial drawdown: D=150, DD_max=300, β=2
         # g = (1 - 150/300)^2 = (1 - 0.5)^2 = 0.5^2 = 0.25
-        haircut = dd_haircut_factor(150.0, dd_max_bps=300.0, beta=2.0)
-        assert abs(haircut - 0.25) < 1e-10
+        haircut = dd_haircut_factor(
+            Decimal("150"), dd_max_bps=Decimal("300"), beta=Decimal("2")
+        )
+        assert haircut == Decimal("0.25")
 
         # Test monotonicity: higher DD → lower haircut
-        h1 = dd_haircut_factor(100.0)
-        h2 = dd_haircut_factor(200.0)
+        h1 = dd_haircut_factor(Decimal("100"))
+        h2 = dd_haircut_factor(Decimal("200"))
         assert h2 < h1
 
     def test_dd_haircut_application(self):
         """Test DD haircut application to Kelly fraction."""
+        from decimal import Decimal
         from core.sizing.kelly import apply_dd_haircut_to_kelly
 
-        kelly_raw = 0.1
+        kelly_raw = Decimal("0.1")
 
         # No DD
-        adjusted = apply_dd_haircut_to_kelly(kelly_raw, 0.0)
+        adjusted = apply_dd_haircut_to_kelly(kelly_raw, Decimal("0"))
         assert adjusted == kelly_raw
 
         # Partial DD
-        adjusted = apply_dd_haircut_to_kelly(kelly_raw, 150.0, dd_max_bps=300.0, beta=2.0)
-        expected = kelly_raw * 0.25  # From previous test
-        assert abs(adjusted - expected) < 1e-10
+        adjusted = apply_dd_haircut_to_kelly(
+            kelly_raw, Decimal("150"), dd_max_bps=Decimal("300"), beta=Decimal("2")
+        )
+        expected = kelly_raw * Decimal("0.25")  # From previous test
+        assert adjusted == expected
 
         # Full DD
-        adjusted = apply_dd_haircut_to_kelly(kelly_raw, 300.0)
-        assert adjusted == 0.0
+        adjusted = apply_dd_haircut_to_kelly(kelly_raw, Decimal("300"))
+        assert adjusted == Decimal("0")
 
     def test_fraction_to_qty_exchange_compliance(self):
         """Test fraction_to_qty with full exchange compliance."""


### PR DESCRIPTION
### **User description**
## Summary
- refactor dd haircut factor and application to use Decimal for precise drawdown handling
- update tests for Decimal-based haircut calculations

## Testing
- `pytest tests/test_sizing_kelly.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c108c7b7e08326b5a4d620f8ce7f24


___

### **PR Type**
Enhancement


___

### **Description**
- Replace float with Decimal for drawdown haircut calculations

- Improve numerical precision in financial risk calculations

- Update function signatures and test cases for Decimal types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Float-based haircut"] --> B["Decimal conversion"]
  B --> C["Precise calculations"]
  C --> D["Updated tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kelly.py</strong><dd><code>Convert drawdown haircut functions to Decimal precision</code>&nbsp; &nbsp; </dd></summary>
<hr>

core/sizing/kelly.py

<ul><li>Import Decimal and InvalidOperation for precise arithmetic<br> <li> Convert <code>dd_haircut_factor</code> parameters and return type to Decimal<br> <li> Update <code>apply_dd_haircut_to_kelly</code> to use Decimal types<br> <li> Replace float operations with Decimal equivalents</ul>


</details>


  </td>
  <td><a href="https://github.com/wekabeka1996/AuroRA/pull/3/files#diff-7491c26c92b0f0a74c63e27863b1dd57e85d8d09b5c1f57241b4e3c213211c01">+35/-33</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sizing_kelly.py</strong><dd><code>Update tests for Decimal-based haircut calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_sizing_kelly.py

<ul><li>Import Decimal in test methods<br> <li> Update test assertions to use Decimal values<br> <li> Replace float literals with Decimal string constructors<br> <li> Maintain exact equality checks for Decimal precision</ul>


</details>


  </td>
  <td><a href="https://github.com/wekabeka1996/AuroRA/pull/3/files#diff-9c5f4c267574c8c079adc9e467cd59e4fd35f223814f0effee779255a51334a6">+21/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

