### PR TITLE
Expose TCA type aliases

### DIFF
--- a/core/tca/__init__.py
+++ b/core/tca/__init__.py
@@ -19,5 +19,6 @@ from .types import TCAInputs as TCAInputsType, TCAComponents as TCAComponentsTyp
 __all__ = [
     "latency", "hazard_cox", "hawkes",
     "TCAAnalyzer", "TCAMetrics", "FillEvent", "OrderExecution",
-    "TCAInputs", "TCAComponents"
+    "TCAInputs", "TCAComponents",
+    "TCAInputsType", "TCAComponentsType", "TCAMetricsType",
 ]


### PR DESCRIPTION
## Summary
- export TCAInputsType, TCAComponentsType, and TCAMetricsType from `core.tca`

## Testing
- `ruff check core/tca/__init__.py --select F401`


------
https://chatgpt.com/codex/tasks/task_e_68c11c063f488326bb479026aceaf50f