### PR TITLE
chore: clean up unused imports in config loader

### DIFF
--- a/core/config/loader.py
+++ b/core/config/loader.py
@@ -5,11 +5,10 @@ import json
 import logging
 import os
 import threading
-import time
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 try:  # Python 3.11+
     import tomllib  # type: ignore


### PR DESCRIPTION
## Summary
- remove unused imports `time` and `Iterable`

## Testing
- `ruff check core/config/loader.py --select F401`


------
https://chatgpt.com/codex/tasks/task_e_68c11c02baf083268fccbd4bc41893bd