### PR TITLE
Remove unused event code imports from AuroraEventLogger

### DIFF
--- a/core/aurora_event_logger.py
+++ b/core/aurora_event_logger.py
@@ -6,15 +6,11 @@ from observability.codes import (
     DQ_EVENT_ABNORMAL_SPREAD, DQ_EVENT_CYCLIC_SEQUENCE,
     AURORA_HALT, AURORA_RESUME, AURORA_EXPECTED_RETURN_ACCEPT,
     AURORA_EXPECTED_RETURN_LOW, AURORA_SLIPPAGE_GUARD,
-    # Step 3 events
-    EXEC_DECISION, ORDER_ACK, ORDER_CXL, ORDER_REPLACE, FILL_EVENT,
-    REWARD_UPDATE, POSITION_CLOSED, TCA_ANALYSIS
 )
 import json
 import time
-from collections import deque
 from pathlib import Path
-from typing import Any, Dict, Optional, Deque, Tuple
+from typing import Any, Dict, Optional
 
 # Reuse robust JSONL writer and small LRU from order logger
 from core.order_logger import _JsonlWriter, _LRUSet  # type: ignore


### PR DESCRIPTION
### **User description**
## Summary
- remove obsolete Step 3 event code imports
- drop unused deque and typing Deque/Tuple imports

## Testing
- `ruff check core/aurora_event_logger.py --select F401`

------
https://chatgpt.com/codex/tasks/task_e_68c11c01904083268387c5bee28843a9


___

### **PR Type**
Other


___

### **Description**
- Remove unused Step 3 event code imports

- Drop unused collections and typing imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AuroraEventLogger"] --> B["Remove Step 3 Events"]
  A --> C["Remove Collections Import"]
  A --> D["Simplify Typing Imports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aurora_event_logger.py</strong><dd><code>Clean up unused imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/aurora_event_logger.py

<ul><li>Remove unused Step 3 event code imports (<code>EXEC_DECISION</code>, <code>ORDER_ACK</code>, <br>etc.)<br> <li> Drop unused <code>collections.deque</code> import<br> <li> Remove unused <code>Deque</code> and <code>Tuple</code> from typing imports</ul>


</details>


  </td>
  <td><a href="https://github.com/wekabeka1996/AuroRA/pull/13/files#diff-27b2809b28e0d7f31396432e03b10c007e860f7b4bf81f66e917c78e66814ec2">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

